### PR TITLE
BaseURL changes due to rename of repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 install: gem install jekyll html-proofer
 script: 
-  - jekyll build && htmlproofer ./_site --url-ignore "/gz-bigindex/*/"
+  - jekyll build && htmlproofer ./_site --url-ignore "/gazebo-doc-index/*/"
   - bundle exec rspec --format doc
 
 # branch whitelist, only for GitHub Pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 ## Contribution guidelines
 
 This document contains guidelines for contributing to Gazebo's [documentation
-index](https://osrf.github.io/gz-bigindex/).
+index](https://osrf.github.io/gazebo-doc-index/).
 
 ### Table of contents
 
-- [About](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#about)
-- [Repository structure](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#repository-structure)
-- [How to contribute](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#how-to-contribute)
-  - [Index structure](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#index-structure)
-  - [Preview changes](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#preview-changes)
-  - [Test the changes](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md#test-the-changes)
+- [About](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#about)
+- [Repository structure](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#repository-structure)
+- [How to contribute](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#how-to-contribute)
+  - [Index structure](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#index-structure)
+  - [Preview changes](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#preview-changes)
+  - [Test the changes](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md#test-the-changes)
 
 ### About
 
@@ -146,7 +146,7 @@ subcategories:
 ---
 ```
 
-Rendering of the above category data can be seen [here](https://osrf.github.io/gz-bigindex/categories/models_import.html).
+Rendering of the above category data can be seen [here](https://osrf.github.io/gazebo-doc-index/categories/models_import.html).
 
 #### Preview changes
 
@@ -154,12 +154,12 @@ Before opening a pull request, proposed changes to the documentation index can
 be previewed by serving the jekyll project on a local server.
 
 ```
-cd gz-bigindex
+cd gazebo-doc-index
 jekyll serve
 ```
 
 For instructions to set up the jekyll project on your machine, refer to the
-repository's [README](https://github.com/osrf/gz-bigindex#getting-started).
+repository's [README](https://github.com/osrf/gazebo-doc-index#getting-started).
 
 ####  Test the changes
 
@@ -167,6 +167,6 @@ Automated tests for validating index structure integrity and external links can 
 
 ```bundle install``` (first time)
 ```bundle exec rspec --format doc``` (index integrity tests)
-```jekyll build && htmlproofer ./_site --url-ignore "/gz-bigindex/*/"``` ([html-proofer](https://github.com/gjtorikian/html-proofer) tests)
+```jekyll build && htmlproofer ./_site --url-ignore "/gazebo-doc-index/*/"``` ([html-proofer](https://github.com/gjtorikian/html-proofer) tests)
 
 Note: Pull requests can't be merged if they don't pass the automated tests.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Status: Under development
 
 #### Setup
 ```
-git clone https://github.com/osrf/gz-bigindex.git
-cd gz-bigindex
+git clone https://github.com/osrf/gazebo-doc-index.git
+cd gazebo-doc-index
 bundle exec jekyll serve
 ```
 
@@ -30,5 +30,5 @@ This folder contains HTML code for the navbar and the footer.
 
 ## Contribution guidelines
 
-Refer to [CONTRIBUTING.md](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md) for information about how to contribute to the project.
+Refer to [CONTRIBUTING.md](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md) for information about how to contribute to the project.
 

--- a/_categories/installing_gazebo.md
+++ b/_categories/installing_gazebo.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Installing the Gazebo simulator"
 desc: "Links related to the Gazebo's installation instructions for different supported platforms"

--- a/_categories/models_import.md
+++ b/_categories/models_import.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Models: Import your existing models"
 desc: "How to import previously existing models created with Gazebo or other external tools (Solidworks, Google Sketchup etc.)."

--- a/_categories/models_joints.md
+++ b/_categories/models_joints.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Models: Defining dynamic relationships between parts (joints)"
 desc: "Instructions to define the dynamic relationships between the different static parts in Gazebo."

--- a/_categories/models_links.md
+++ b/_categories/models_links.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Models: Create static objects in Gazebo (links)"
 desc: "How to create or define static objects in the Gazebo simulator using different approaches (GUI, code, ...) and tools."

--- a/_categories/physics_params.md
+++ b/_categories/physics_params.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Physics: Simulation physics parameters"
 desc: "Description of parameters affecting a simulation and how to select good values for every case."

--- a/_categories/sensors.md
+++ b/_categories/sensors.md
@@ -1,6 +1,6 @@
 ---
 # Contribution guidelines:
-# https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md 
+# https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md 
 
 title: "Sensors: The sensor catalogue"
 desc: "How to add already implemented sensors (camera, lasers, IMU, ...) to the gazebo models."

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: Gazebo documentation index
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
   A documentation index for Gazebo  - containing learning resources for Gazebo from all over the internet.
-baseurl: "/gz-bigindex" # the subpath of your site, e.g. /blog
+baseurl: "/gazebo-doc-index" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -15,7 +15,7 @@ layout: "wrapper"
             <h1>{{page.title}}</h1>
             <hr>
             <div class="col-md-offset-9 col-xs-offset-8">
-                <a href="https://github.com/osrf/gz-bigindex/edit/master/{{page.path}}">
+                <a href="https://github.com/osrf/gazebo-doc-index/edit/master/{{page.path}}">
                 <i class="glyphicon glyphicon-edit" style="margin-right:3px"></i>
                 Suggest edits
                 </a>
@@ -28,9 +28,7 @@ layout: "wrapper"
             <ul>
                 <div class="col-xs-12 item-container">
                     {% for item in subcategory.items %} 
-                    <div style="margin-bottom: 15px">
-
-                                      
+                    <div class="index-item">
                     <li>
                         <p class="item-title">
                             {% if item.star %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -109,11 +109,15 @@ h1 {
 }
 
 .cat-card {
-  min-height: 160px;
+  min-height: 170px;
 }
 
 .cat-desc {
   margin-top: 12px;
+}
+
+.index-item {
+  margin-bottom: 15px;
 }
 
 .item-title {

--- a/design_spec.md
+++ b/design_spec.md
@@ -114,7 +114,7 @@ Contributions can be made by updating the index items, their descriptions,
 categories or subcategories, using pull requests. 
 
 For information about how to contribute to the project, contribution guidelines
-can be referred to [here](https://github.com/osrf/gz-bigindex/blob/master/CONTRIBUTING.md).
+can be referred to [here](https://github.com/osrf/gazebo-doc-index/blob/master/CONTRIBUTING.md).
 
 ### 4.4 User interface
 
@@ -196,7 +196,7 @@ subcategories:
 
 ### 4.6 Hosting
 
-The website is being served using Github pages. It can be accessed [here](https://osrf.github.io/gz-bigindex/).
+The website is being served using Github pages. It can be accessed [here](https://osrf.github.io/gazebo-doc-index/).
 
 
 ## 5. Progress

--- a/suggestions-tool/README.md
+++ b/suggestions-tool/README.md
@@ -18,7 +18,7 @@ python3 -m pip install flask numpy rake-ntlk requests
 ### How to run locally:
 
 ```
-cd gz-bigindex/suggestions-tool/web
+cd gazebo-doc-index/suggestions-tool/web
 npm install
 npm run build
 cd ../api


### PR DESCRIPTION
Changes to accommodate for renaming of repository from `gz-bigindex` to `gazebo-doc-index`.